### PR TITLE
Improve the performance of Adler-32 and decoding. Validate against .NET 5

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Build and test
 
 on: [push, pull_request]
 
@@ -12,11 +12,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Setup .NET SDK
+
+    - name: "Setup .NET SDK"
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.100
+        dotnet-version: 5.0.101
+
+    - name: Setup .NET 3.1 runtime
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.404
+
     - name: Build
       run: dotnet build -c Release
+
     - name: Test
       run: dotnet test -c Release --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ TestResult.xml
 artifacts/
 coverage/
 tools/
-xdelta.PerformanceTests/BenchmarkDotNet.Artifacts/*
+BenchmarkDotNet.Artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ TestResult.xml
 artifacts/
 coverage/
 tools/
+xdelta.PerformanceTests/BenchmarkDotNet.Artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ obj/
 # NuGet
 packages/
 
-# NUnit output
+# Test output
 TestResult.xml
+artifacts/
+coverage/
+tools/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 SceneGate
+Copyright (c) 2019 Benito Palacios Sánchez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xdelta-sharp ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pleonex/xdelta-sharp/.NET%20Core) ![GitHub](https://img.shields.io/github/license/pleonex/xdelta-sharp)
+# xdelta-sharp ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/pleonex/xdelta-sharp/build%20and%20test) ![GitHub](https://img.shields.io/github/license/pleonex/xdelta-sharp)
 
 **NOTE: At this stage, this projects can only decompress patch files. It cannot generate / compress.**
 

--- a/Tests.runsettings
+++ b/Tests.runsettings
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Put results in root folder rather inside each project-->
+    <ResultsDirectory>./artifacts/test_results</ResultsDirectory>
+  </RunConfiguration>
+
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <!-- .NET command-line coverage tool -->
+      <!-- https://github.com/tonerdo/coverlet/blob/master/Documentation/VSTestIntegration.md -->
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[.*UnitTest]*,[.*IntegrationTest]*</Exclude>
+          <ExcludeByAttribute>GeneratedCodeAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/xdelta.Cli/xdelta.Cli.csproj
+++ b/xdelta.Cli/xdelta.Cli.csproj
@@ -8,7 +8,7 @@
     <Authors>Benito Palacios Sánchez</Authors>
     <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
 
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <CodeAnalysisRuleSet></CodeAnalysisRuleSet>
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <PackageProjectUrl>https://github.com/pleonex/xdelta-sharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pleonex/xdelta-sharp</RepositoryUrl>
-    <License>GPL-3</License>
+    <License>MIT</License>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageIcon></PackageIcon>
     <PackageTags>decompress;vcdiff;rfc3284;xdelta</PackageTags>

--- a/xdelta.PerformanceTests/Adler32Tests.cs
+++ b/xdelta.PerformanceTests/Adler32Tests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Benito Palacios Sánchez
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Xdelta.PerformanceTests
+{
+    using System.IO;
+    using BenchmarkDotNet.Attributes;
+
+    public class Adler32Tests
+    {
+        Stream stream;
+
+        [Params(2 * 1024, 512 * 1024, 4 * 1024 * 1024)]
+        public uint Length { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            stream = new MemoryStream();
+            byte[] data = new byte[Length];
+            for (int i = 0; i < Length; i++) {
+                data[i] = (byte)(i % 256);
+            }
+
+            stream.Write(data, 0, data.Length);
+        }
+
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            stream.Dispose();
+        }
+
+        [Benchmark]
+        public uint Adler32Run()
+        {
+            stream.Position = 0;
+            return Adler32.Run(1, stream, Length);
+        }
+    }
+}

--- a/xdelta.PerformanceTests/Adler32Tests.cs
+++ b/xdelta.PerformanceTests/Adler32Tests.cs
@@ -22,6 +22,7 @@ namespace Xdelta.PerformanceTests
     using System.IO;
     using BenchmarkDotNet.Attributes;
 
+    [MemoryDiagnoser]
     public class Adler32Tests
     {
         Stream stream;
@@ -51,7 +52,7 @@ namespace Xdelta.PerformanceTests
         public uint Adler32Run()
         {
             stream.Position = 0;
-            return Adler32.Run(1, stream, Length);
+            return Adler32.Run(stream, Length);
         }
     }
 }

--- a/xdelta.PerformanceTests/Program.cs
+++ b/xdelta.PerformanceTests/Program.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2019 Benito Palacios Sánchez
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Xdelta.PerformanceTests
+{
+    using System;
+    using BenchmarkDotNet.Running;
+
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<Adler32Tests>();
+        }
+    }
+}

--- a/xdelta.PerformanceTests/Xdelta.PerformanceTests.csproj
+++ b/xdelta.PerformanceTests/Xdelta.PerformanceTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Product>Xdelta</Product>
+    <Description>Performance tests of the library.</Description>
+    <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
+    <Authors>Benito Palacios Sánchez</Authors>
+
+    <Version>1.1</Version>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\xdelta\xdelta.csproj" />
+
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+</Project>

--- a/xdelta.PerformanceTests/Xdelta.PerformanceTests.csproj
+++ b/xdelta.PerformanceTests/Xdelta.PerformanceTests.csproj
@@ -7,7 +7,7 @@
     <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
     <Authors>Benito Palacios Sánchez</Authors>
 
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <TargetFramework>net5.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/xdelta.UnitTests/Adler32Tests.cs
+++ b/xdelta.UnitTests/Adler32Tests.cs
@@ -19,21 +19,33 @@
 // SOFTWARE.
 namespace Xdelta.UnitTests
 {
+    using System;
     using System.IO;
     using NUnit.Framework;
 
     [TestFixture]
     public class Adler32Tests
     {
-        const int InitAdler = 1;
         const int NMax = 5552;
+
+        [Test]
+        public void Guards()
+        {
+            using var stream = new MemoryStream();
+            stream.Write(new byte[] { 1, 2, 3, 4 }, 0, 4);
+            stream.Position = 2;
+
+            Assert.That(() => Adler32.Run(null, 0), Throws.ArgumentNullException);
+            Assert.That(() => Adler32.Run(stream, -2), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            Assert.That(() => Adler32.Run(stream, 3), Throws.InstanceOf<EndOfStreamException>());
+        }
 
         [Test]
         public void EmptyStream()
         {
             using var stream = new MemoryStream();
 
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(1));
         }
@@ -45,7 +57,7 @@ namespace Xdelta.UnitTests
             stream.WriteByte(0xCA);
 
             stream.Position = 0;
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(13304011));
         }
@@ -57,7 +69,7 @@ namespace Xdelta.UnitTests
             stream.WriteByte(0xCA);
 
             stream.Position = 0;
-            uint result = Adler32.Run((65530u << 16) | 65530u, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length, (65530u << 16) | 65530u);
 
             Assert.That(result, Is.EqualTo(14418131));
         }
@@ -69,7 +81,7 @@ namespace Xdelta.UnitTests
             stream.Write(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF, }, 0, 8);
 
             stream.Position = 0;
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(491128441));
         }
@@ -81,7 +93,7 @@ namespace Xdelta.UnitTests
             stream.Write(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF, }, 0, 8);
 
             stream.Position = 0;
-            uint result = Adler32.Run((65530u << 16) | 65530u, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length, (65530u << 16) | 65530u);
 
             Assert.That(result, Is.EqualTo(495912577));
         }
@@ -91,7 +103,7 @@ namespace Xdelta.UnitTests
         {
             using var stream = GetTestStream(NMax - 100);
 
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(3475765439));
         }
@@ -101,7 +113,7 @@ namespace Xdelta.UnitTests
         {
             using var stream = GetTestStream(NMax);
 
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(2367181278));
         }
@@ -111,7 +123,7 @@ namespace Xdelta.UnitTests
         {
             using var stream = GetTestStream(NMax * 4 + 100);
 
-            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+            uint result = Adler32.Run(stream, stream.Length);
 
             Assert.That(result, Is.EqualTo(2570494100));
         }

--- a/xdelta.UnitTests/Adler32Tests.cs
+++ b/xdelta.UnitTests/Adler32Tests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) 2019 Benito Palacios Sánchez
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+namespace Xdelta.UnitTests
+{
+    using System.IO;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Adler32Tests
+    {
+        const int InitAdler = 1;
+        const int NMax = 5552;
+
+        [Test]
+        public void EmptyStream()
+        {
+            using var stream = new MemoryStream();
+
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SingleByte()
+        {
+            using var stream = new MemoryStream();
+            stream.WriteByte(0xCA);
+
+            stream.Position = 0;
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(13304011));
+        }
+
+        [Test]
+        public void SingleByteWithContinuation()
+        {
+            using var stream = new MemoryStream();
+            stream.WriteByte(0xCA);
+
+            stream.Position = 0;
+            uint result = Adler32.Run((65530u << 16) | 65530u, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(14418131));
+        }
+
+        [Test]
+        public void SmallerThan16Bytes()
+        {
+            using var stream = new MemoryStream();
+            stream.Write(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF, }, 0, 8);
+
+            stream.Position = 0;
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(491128441));
+        }
+
+        [Test]
+        public void SmallerThan16BytesWithContinuation()
+        {
+            using var stream = new MemoryStream();
+            stream.Write(new byte[] { 0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF, }, 0, 8);
+
+            stream.Position = 0;
+            uint result = Adler32.Run((65530u << 16) | 65530u, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(495912577));
+        }
+
+        [Test]
+        public void SmallerThanNMax()
+        {
+            using var stream = GetTestStream(NMax - 100);
+
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(3475765439));
+        }
+
+        [Test]
+        public void LengthLikeNMax()
+        {
+            using var stream = GetTestStream(NMax);
+
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(2367181278));
+        }
+
+        [Test]
+        public void BiggerThanNMax()
+        {
+            using var stream = GetTestStream(NMax * 4 + 100);
+
+            uint result = Adler32.Run(InitAdler, stream, (uint)stream.Length);
+
+            Assert.That(result, Is.EqualTo(2570494100));
+        }
+
+        Stream GetTestStream(long length)
+        {
+            var stream = new MemoryStream();
+            var data = new byte[] { 0xCA, 0xFE };
+            for (int i = 0; i < length / data.Length; i++) {
+                stream.Write(data, 0, data.Length);
+            }
+
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/xdelta.UnitTests/xdelta.UnitTests.csproj
+++ b/xdelta.UnitTests/xdelta.UnitTests.csproj
@@ -9,7 +9,7 @@
     <Authors>Benito Palacios Sánchez</Authors>
 
     <Version>1.1</Version>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/xdelta.UnitTests/xdelta.UnitTests.csproj
+++ b/xdelta.UnitTests/xdelta.UnitTests.csproj
@@ -10,6 +10,7 @@
 
     <Version>1.1</Version>
     <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
+    <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -19,6 +20,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
 
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/xdelta.UnitTests/xdelta.UnitTests.csproj
+++ b/xdelta.UnitTests/xdelta.UnitTests.csproj
@@ -8,7 +8,7 @@
     <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
     <Authors>Benito Palacios Sánchez</Authors>
 
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>

--- a/xdelta.sln
+++ b/xdelta.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xdelta.UnitTests", "xdelta.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xdelta.Cli", "xdelta.Cli\xdelta.Cli.csproj", "{773349A8-4924-4C83-857C-522EF949B813}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xdelta.PerformanceTests", "xdelta.PerformanceTests\Xdelta.PerformanceTests.csproj", "{DF38AA30-930F-41D4-8555-D85689AEE32B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,5 +60,17 @@ Global
 		{773349A8-4924-4C83-857C-522EF949B813}.Release|x64.Build.0 = Release|Any CPU
 		{773349A8-4924-4C83-857C-522EF949B813}.Release|x86.ActiveCfg = Release|Any CPU
 		{773349A8-4924-4C83-857C-522EF949B813}.Release|x86.Build.0 = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|x64.Build.0 = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Debug|x86.Build.0 = Debug|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|x64.ActiveCfg = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|x64.Build.0 = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|x86.ActiveCfg = Release|Any CPU
+		{DF38AA30-930F-41D4-8555-D85689AEE32B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/xdelta/Adler32.cs
+++ b/xdelta/Adler32.cs
@@ -43,6 +43,7 @@
 namespace Xdelta
 {
     using System;
+    using System.Buffers;
     using System.IO;
 
     /// <summary>
@@ -82,9 +83,8 @@ namespace Xdelta
             uint sumA = start & 0xFFFF;
             uint sumB = start >> 16;
 
-            byte[] buffer = new byte[MaxModuleBlock];
-
             // Computes the checksum in blocks that requires maximum one modulo
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(MaxModuleBlock);
             while (length > 0) {
                 int read = stream.Read(buffer, 0, MaxModuleBlock);
                 length -= read;
@@ -98,6 +98,7 @@ namespace Xdelta
                 sumB %= SumModulo;
             }
 
+            ArrayPool<byte>.Shared.Return(buffer);
             return sumA | (sumB << 16);
         }
     }

--- a/xdelta/Adler32.cs
+++ b/xdelta/Adler32.cs
@@ -40,89 +40,65 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-using System.IO;
-
 namespace Xdelta
 {
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Adler-32 checksum algorithm.
+    /// </summary>
+    /// <remarks>
+    /// <para>For more information: https://en.wikipedia.org/wiki/Adler-32</para>
+    /// </remarks>
     public static class Adler32
     {
-        private const uint Base = 65521;    // Largest prime smaller than 65536
-        private const uint Nmax = 5552;        // Nmax is the largest n such that 255n(n+1)/2 + (n+1)(Base-1) <= 2^32-1
+        // By definition the algorithm starts with value 1.
+        private const uint StartValue = 1;
 
-        private static void DoTimes(ref uint adler, ref uint sum2, Stream buffer, int times)
+         // Modulo of the sums. Largest prime smaller than 65536
+        private const int SumModulo = 65521;
+
+        // Max number of bytes that requires a maximum one modulo.
+        // Largest n such that 255n(n+1)/2 + (n+1)(Base-1) <= 2^32-1
+        private const int MaxModuleBlock = 5552;
+
+        /// <summary>
+        /// Computes the checksum Adler-32 from a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read data. It starts at the current position.</param>
+        /// <param name="length">The amount of bytes to read from the stream for the checksum.</param>
+        /// <param name="start">The start value of the checksum.</param>
+        /// <returns>The Adler-32 checksum of the data.</returns>
+        public static uint Run(Stream stream, long length, uint start = StartValue)
         {
-            while (times-- > 0) {
-                adler += (byte)buffer.ReadByte();
-                sum2  += adler;
-            }
-        }
+            if (stream == null)
+                throw new ArgumentNullException(nameof(stream));
+            if (length < 0)
+                throw new ArgumentOutOfRangeException(nameof(length), length, "Invalid length");
+            if (stream.Position + length > stream.Length)
+                throw new EndOfStreamException("Not enough bytes to read.");
 
-        public static uint Run(uint adler, Stream buffer, uint length)
-        {
-            uint n;
+            uint sumA = start & 0xFFFF;
+            uint sumB = start >> 16;
 
-            // Split Adler-32 into component sums
-            uint sum2 = (adler >> 16) & 0xFFFF;
-            adler &= 0xFFFF;
+            byte[] buffer = new byte[MaxModuleBlock];
 
-            // In case user likes doing a byte at a time, keep it fast
-            if (length == 1) {
-                adler += (byte)buffer.ReadByte();
-                if (adler >= Base)
-                    adler -= Base;
+            // Computes the checksum in blocks that requires maximum one modulo
+            while (length > 0) {
+                int read = stream.Read(buffer, 0, MaxModuleBlock);
+                length -= read;
 
-                sum2 += adler;
-                if (sum2 >= Base)
-                    sum2 -= Base;
-
-                return adler | (sum2 << 16);
-            }
-
-            // In case short lengths are provided, keep it somewhat fast
-            if (length < 16) {
-                while (length-- > 0) {
-                    adler += (byte)buffer.ReadByte();
-                    sum2  += adler;
+                for (int i = 0; i < read; i++) {
+                    sumA += buffer[i];
+                    sumB += sumA;
                 }
 
-                if (adler >= Base)
-                    adler -= Base;
-
-                sum2 %= Base;
-                return adler | (sum2 << 16);
+                sumA %= SumModulo;
+                sumB %= SumModulo;
             }
 
-            // Do length Nmax blocks -- requires just one module operation
-            while (length >= Nmax) {
-                length -= Nmax;
-                n = Nmax / 16;                            // Nmax is divisible by 16
-                do
-                    DoTimes(ref adler, ref sum2, buffer, 16);    // 16 sums unrolled
-                while (--n > 0);
-
-                adler %= Base;
-                sum2  %= Base;
-            }
-
-            // Do remaining bytes (less than Nmax, still just one module)
-            if (length > 0) {    // avoid modules if none remaining
-                while (length >= 16) {
-                    length -= 16;
-                    DoTimes(ref adler, ref sum2, buffer, 16);
-                }
-
-                while (length-- > 0) {
-                    adler += (byte)buffer.ReadByte();
-                    sum2 += adler;
-                }
-
-                adler %= Base;
-                sum2  %= Base;
-            }
-
-            // return recombined sums
-            return adler | (sum2 << 16);
+            return sumA | (sumB << 16);
         }
     }
 }
-

--- a/xdelta/Decoder/WindowDecoder.cs
+++ b/xdelta/Decoder/WindowDecoder.cs
@@ -61,7 +61,7 @@ namespace Xdelta
             // Check checksum
             if (window.Source.HasFlag(WindowFields.Adler32)) {
                 output.Position = window.TargetWindowOffset;
-                uint newAdler = Adler32.Run(1, output, window.TargetWindowLength);
+                uint newAdler = Adler32.Run(output, window.TargetWindowLength);
                 if (newAdler != window.Checksum)
                     throw new Exception("Invalid checksum");
             }

--- a/xdelta/xdelta.csproj
+++ b/xdelta/xdelta.csproj
@@ -8,7 +8,7 @@
     <Authors>Benito Palacios Sánchez</Authors>
     <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
 
-    <Version>1.1</Version>
+    <Version>1.2</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet></CodeAnalysisRuleSet>

--- a/xdelta/xdelta.csproj
+++ b/xdelta/xdelta.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Decoding a window of data requires running the checksum algorithm Adler-32 to verify the decoding was successful. There was a major performance issue and this checksum algorithm was very complex and inefficient.

I have added unit tests and a performance test. Results:

Original

```
|     Method |  Length |          Mean |       Error |      StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |-------- |--------------:|------------:|------------:|------:|------:|------:|----------:|
| Adler32Run |    2048 |      5.999 us |   0.1135 us |   0.1627 us |     - |     - |     - |         - |
| Adler32Run |  524288 |  1,583.961 us |  29.7528 us |  56.6077 us |     - |     - |     - |       1 B |
| Adler32Run | 4194304 | 13,057.855 us | 247.3469 us | 553.2267 us |     - |     - |     - |       4 B |
```

After improvement

```
|     Method |  Length |         Mean |      Error |     StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |-------- |-------------:|-----------:|-----------:|------:|------:|------:|----------:|
| Adler32Run |    2048 |     1.357 us |  0.0111 us |  0.0093 us |     - |     - |     - |         - |
| Adler32Run |  524288 |   333.501 us |  1.7935 us |  1.5899 us |     - |     - |     - |         - |
| Adler32Run | 4194304 | 2,760.907 us | 15.1725 us | 12.6697 us |     - |     - |     - |       1 B |
```

2 KB   -> 77.3%
512 KB -> 78.9%
4 MB   -> 78.9%

Also validate the tests against .NET 5