### PR TITLE
Validate API with .NET 6 and update build system

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.3.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,9 @@
-# TODO #35 Support Ubuntu 20.04
-FROM mcr.microsoft.com/vscode/devcontainers/dotnetcore:0.148.1-3.1
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 
-# Install .NET 5.0
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y apt-transport-https \
-    && wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
-    && dpkg -i packages-microsoft-prod.deb \
-    && apt-get update \
-    && apt-get install -y dotnet-sdk-5.0
-
-# Install Mono (soon won't be necessary (.NET 6?))
-RUN apt install gnupg ca-certificates \
+# Install Mono (for DocFX)
+RUN apt install -y apt-transport-https dirmngr gnupg ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" >> /etc/apt/sources.list.d/mono-official-stable.list \
+    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" >> tee /etc/apt/sources.list.d/mono-official-stable.list \
     && apt update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y mono-devel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
-    "name": "Dev (Ubuntu - .NET 5, 3.1 and Mono)",
+    "name": "Dev (.NET 6 and Mono)",
     "build": {
         "dockerfile": "Dockerfile",
-    },
-
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
     },
 
     "extensions": [

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -14,7 +14,7 @@ on:
       - published
 
 env:
-  NET_SDK: '5.0.101'
+  NET_SDK: '6.0.100'
 
 jobs:
   build_main:
@@ -30,10 +30,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -79,10 +75,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: dotnet tool restore
@@ -117,10 +109,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.NET_SDK }}
-      - name: "Setup .NET Core 3.1 for Cake dependencies"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.404'
 
       - name: "Install build tools"
         run: dotnet tool restore

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ The latest version does not support:
 - Generate patch files.
 - Patch files with external compression.
 
+## Examples
+
+- Apply a patch file
+
+```csharp
+using var input = new FileStream(inputFile, FileMode.Open);
+using var patch = new FileStream(patchFile, FileMode.Open);
+using var output = new FileStream(outputFile, FileMode.Create);
+
+using var decoder = new Decoder(input, patch, output);
+decoder.ProgressChanged += progress => Console.WriteLine($"Patching progress: {progress}";
+
+decoder.Run();
+```
+
 ## Documentation
 
 Feel free to ask any question in the

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 **NOTE: At this stage, this projects can only decompress patch files. It cannot
 generate / compress.**
 
-**xdelta-sharp** is a compression tool to create delta/patch files from binary
-files using the algorithm `VCDIFF` described in the
+**Pleosoft.XdeltaSharp** offers the possibility to apply delta/patch files with
+format `VCDIFF`, as described in the
 [RFC 3284](https://tools.ietf.org/html/rfc3284).
 
-This projects offers a library and a console application written in pure C# (no
+This project offers a library and a console application written in pure C# (no
 calls to C libraries). Making it compatible in every OS that can run a .NET
-runtime that implements .NET Standard 2.0.
+runtime that implements .NET Standard 2.0 (.NET Framework, Mono and .NET).
 
 <!-- prettier-ignore -->
 | Release | Package                                                           |
@@ -38,9 +38,8 @@ Check our on-line [API documentation](https://pleonex.dev/xdelta-sharp/).
 
 ## Build
 
-The project requires to build .NET 5.0 SDK, .NET Core 3.1 runtime and .NET
-Framework 4.8 or latest Mono. If you open the project with VS Code and you did
-install the
+The project requires to build .NET 6.0 SDK and .NET Framework 4.8 or latest
+Mono. If you open the project with VS Code and you did install the
 [VS Code Remote Containers](https://code.visualstudio.com/docs/remote/containers)
 extension, you can have an already pre-configured development environment with
 Docker or Podman.

--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&version=0.4.0"
+#load "nuget:?package=PleOps.Cake&version=0.6.0"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,11 @@
         <Copyright>Copyright (C) 2015 Benito Palacios Sánchez</Copyright>
 
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+
+        <!-- Due to known issues, .NET 6 SDK may give a false warning
+             when packing apps if the SelfContained value is in the csproj
+             instead in the CLI command. -->
+        <NoWarn>NETSDK1179</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -13,6 +18,7 @@
         <RepositoryUrl>https://github.com/pleonex/xdelta-csharp</RepositoryUrl>
         <!-- <PackageIcon>icon.png</PackageIcon> -->
         <PackageTags>decompress;vcdiff;rfc3284;xdelta</PackageTags>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <!-- Deterministic and source link -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,16 +3,16 @@
     <ItemGroup>
         <PackageVersion Include="System.Buffers" Version="4.5.1" />
 
-        <PackageVersion Include="nunit" Version="3.12.0" />
-        <PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.8.3"/>
-        <PackageVersion Include="coverlet.collector" Version="1.3.0" />
-        <PackageVersion Include="BenchmarkDotNet" Version="0.12.1" />
+        <PackageVersion Include="nunit" Version="3.13.2" />
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+        <PackageVersion Include="coverlet.collector" Version="3.1.0" />
+        <PackageVersion Include="BenchmarkDotNet" Version="0.13.1" />
 
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.15.0.24505" />
-        <PackageVersion Include="Roslynator.Analyzers" Version="3.0.0" />
+        <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.32.0.39516" />
+        <PackageVersion Include="Roslynator.Analyzers" Version="3.3.0" />
     </ItemGroup>
 </Project>

--- a/src/Pleosoft.XdeltaSharp.Cli/Pleosoft.XdeltaSharp.Cli.csproj
+++ b/src/Pleosoft.XdeltaSharp.Cli/Pleosoft.XdeltaSharp.Cli.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>XdeltaSharp</AssemblyName>
     <Description>Decompressor of VCDIFF patch files (RFC3284).</Description>
     <RootNamespace>Pleosoft.XdeltaSharp.Cli</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>

--- a/src/Pleosoft.XdeltaSharp.PerformanceTests/Pleosoft.XdeltaSharp.PerformanceTests.csproj
+++ b/src/Pleosoft.XdeltaSharp.PerformanceTests/Pleosoft.XdeltaSharp.PerformanceTests.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <Description>Performance tests of the library.</Description>
     <RootNamespace>Pleosoft.XdeltaSharp.PerformanceTests</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Pleosoft.XdeltaSharp.UnitTests/Pleosoft.XdeltaSharp.UnitTests.csproj
+++ b/src/Pleosoft.XdeltaSharp.UnitTests/Pleosoft.XdeltaSharp.UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Unit tests of the library.</Description>
     <RootNamespace>Pleosoft.XdeltaSharp.UnitTests</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1;net48;net5.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/Pleosoft.XdeltaSharp/Pleosoft.XdeltaSharp.csproj
+++ b/src/Pleosoft.XdeltaSharp/Pleosoft.XdeltaSharp.csproj
@@ -6,9 +6,10 @@
     <RootNamespace>Pleosoft.XdeltaSharp</RootNamespace>
   </PropertyGroup>
 
-  <!-- <ItemGroup>
-    <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" />
-  </ItemGroup> -->
+  <ItemGroup>
+    <!-- <None Include="../../docs/images/logo_128.png" Pack="true" PackagePath="$(PackageIcon)" Visible="false" /> -->
+    <None Include="../../README.md" Pack="true" PackagePath="$(PackageReadmeFile)"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" />


### PR DESCRIPTION
### Description

Run the unit tests against .NET 6 runtime and compile executables for it.
Update build system and dev files.
