### PR TITLE
Fix throwing exception when win_indicator is zero

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-#load "nuget:?package=PleOps.Cake&version=0.6.0"
+#load "nuget:?package=PleOps.Cake&version=0.6.1"
 
 Task("Define-Project")
     .Description("Fill specific project information")

--- a/src/Pleosoft.XdeltaSharp/Vcdiff/Instructions/Copy.cs
+++ b/src/Pleosoft.XdeltaSharp/Vcdiff/Instructions/Copy.cs
@@ -44,9 +44,6 @@ namespace Pleosoft.XdeltaSharp.Vcdiff.Instructions
             uint hereAddress = window.SourceSegmentLength + ((uint)output.Position - window.TargetWindowOffset);
             Address = cache.GetAddress(hereAddress, binaryMode, window.Addresses);
 
-            if (!window.Source.HasFlag(WindowFields.Source) && !window.Source.HasFlag(WindowFields.Target))
-                throw new InvalidOperationException("Trying to copy from unknown source");
-
             CopyFromSourceWindow(window, input, output);
             CopyFromTargetWindow(window, output); // Not always
         }


### PR DESCRIPTION
### Description

The logic for the copy instruction when the Windows indicator is zero (nor source or target) is already implemented. It should be copying from the window itself. So we just need to remove the exception. Tested with some patches.